### PR TITLE
Update CipherStash gem versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in activerecord-postgis-adapter.gemspec
 gemspec
 
-gem "cipherstash-pg", ">= 1.0.0.beta.9"
+gem "cipherstash-pg", ">= 1.0.0.beta.22"
 gem "byebug" if ENV["BYEBUG"]
 
 def activerecord_version

--- a/activerecord-postgis-adapter.gemspec
+++ b/activerecord-postgis-adapter.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 3.0.0"
 
   spec.add_dependency "activerecord", "~> 7.1.0"
-  spec.add_dependency 'activerecord-cipherstash-pg-adapter', "~> 0.7.10"
+  spec.add_dependency 'activerecord-cipherstash-pg-adapter', "~> 0.8.5"
   spec.add_dependency "rgeo-activerecord", "~> 7.0.0"
 
   spec.add_development_dependency "rake", "~> 13.0"


### PR DESCRIPTION
Update gem versions to beta.22 and 0.8.5.